### PR TITLE
Correct paths in documentation URLs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Contents:
     :target: http://oscarcommerce.com
 
 .. image:: https://github.com/django-oscar/django-oscar/raw/master/docs/images/screenshots/readthedocs.thumb.png
-    :target: https://django-oscar.readthedocs.io/en/stable/
+    :target: https://django-oscar.readthedocs.io/en/latest/
 
 Further reading:
 
@@ -141,8 +141,8 @@ The sandbox site is also available to browse at https://latest.oscarcommerce.com
 The sandbox site can be set-up locally `in 5 commands`_.  Want to
 make changes?  Check out the `contributing guidelines`_.
 
-.. _`in 5 commands`: https://django-oscar.readthedocs.io/en/stable/internals/sandbox.html#running-the-sandbox-locally
-.. _`contributing guidelines`: https://django-oscar.readthedocs.io/en/stable/internals/contributing/index.html
+.. _`in 5 commands`: https://django-oscar.readthedocs.io/en/latest/internals/sandbox.html#running-the-sandbox-locally
+.. _`contributing guidelines`: https://django-oscar.readthedocs.io/en/latest/internals/contributing/index.html
 
 
 Extensions

--- a/README.rst
+++ b/README.rst
@@ -141,7 +141,7 @@ The sandbox site is also available to browse at https://latest.oscarcommerce.com
 The sandbox site can be set-up locally `in 5 commands`_.  Want to
 make changes?  Check out the `contributing guidelines`_.
 
-.. _`in 5 commands`: https://django-oscar.readthedocs.io/en/latest/internals/sandbox.html#running-the-sandbox-locally
+.. _`in 5 commands`: https://django-oscar.readthedocs.io/en/latest/internals/sandbox.html#run-the-sandbox-locally
 .. _`contributing guidelines`: https://django-oscar.readthedocs.io/en/latest/internals/contributing/index.html
 
 


### PR DESCRIPTION
💁 I was reading through the documentation for this project and noticed some broken links. These changes update documentation links to their correct URLs.